### PR TITLE
Update building.md

### DIFF
--- a/linux/kernel/building.md
+++ b/linux/kernel/building.md
@@ -76,7 +76,7 @@ KERNEL=kernel7l
 make bcm2711_defconfig
 ```
 
-##### If on the Raspberry Pi OS (64-bit)
+##### If on the Raspberry Pi OS (64-bit) beta
 
 ###### Raspberry Pi 3, Pi 3+, and Compute Module 3 default build configuration
 
@@ -118,7 +118,7 @@ sudo cp arch/arm/boot/dts/overlays/README /boot/overlays/
 sudo cp arch/arm/boot/zImage /boot/$KERNEL.img
 ```
 
-#### If on the Raspberry Pi OS (64-bit)
+#### If on the Raspberry Pi OS (64-bit) beta
 **Note**: The 64-bit kernel is in "Image" vs "zImage"
 ```bash
 make -j4 Image modules dtbs


### PR DESCRIPTION
.... change from "Raspberry Pi OS 64-bit" to "Raspberry Pi OS 64-bit beta" in an effort to keep the logical flow from a user's perspective in light of the availability of the 64-bit beta versions (full and lite) and the political sensitiveness of using the 64-bit reference which is not formally released but is currently and has been for some time in beta release, which is openly being used in the wild.